### PR TITLE
Added functionality for sending private messages

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -51,7 +51,13 @@ Both arguments should be strings. Setting a status is flow specific.
 ```javascript
 session.message('example:main', 'Isn\'t this cool?');
 ```
-Both arguments should be strings. Ssing a message is flow specific.
+Both arguments should be strings. Sending a message is flow specific.
+
+#### Post a chat message to a private chat
+```javascript
+session.message(12345, 'Hi, this is a secret message!');
+```
+The first argument is the recipient's ID, and has to be a number.
 
 #### Fetch and stream all the flows your user has an access
 

--- a/src/flowdock.coffee
+++ b/src/flowdock.coffee
@@ -42,9 +42,17 @@ class Session extends process.EventEmitter
     Stream.connect @auth, flows, options
 
   # Send message to flowdock
+  # 
+  # flow - Either a flow name (String <subdomain>:<flow>) or a user id (Number)
+  # message - The message to send
+  # callback - Optional callback function
   send: (flow, message, callback) ->
     uri = baseURL()
-    uri.path = "/flows/#{flow.replace ':', '/'}/messages"
+
+    if 'number' is typeof flow
+      uri.path = "/private/#{flow}/messages" 
+    else
+      uri.path = "/flows/#{flow.replace ':', '/'}/messages"
 
     options =
       uri: uri


### PR DESCRIPTION
Private messages can now be send as follows:

```
session.message(12345, 'Hi, this is a private message!');
```

The first argument is the recipient's ID and has to be a number.

Related issue: flowdock/hubot-flowdock#20
