### PR TITLE
Message sending method callbacks receive error as first param

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -64,7 +64,7 @@ The full message format specification for different message types is in [Flowdoc
 
 ### Sending messages
 
-Session has several methods to send messages to Flowdock. All methods except `status` support adding tags to the messages too. You can optionally supply a callback as the last parameter, that gets the created message and the response as parameters.
+Session has several methods to send messages to Flowdock. All methods except `status` support adding tags to the messages too. You can optionally supply a callback as the last parameter, with the signature `-> (err, message, res)`, where message is the created message and res is the raw response object.
 
 #### Set your status for a flow
 ```javascript
@@ -123,3 +123,7 @@ The full message format specification for different message types is in [Flowdoc
 ## Development
 
 You'll need `coffee-script`, `mocha` and `colors` for development, just run `npm install`. Code can be compiled to .js with command `make build`.
+
+## Changes
+
+v. 0.7 - Message callbacks conform to node standard with -> (err, body, res) signature

--- a/src/flowdock.coffee
+++ b/src/flowdock.coffee
@@ -62,14 +62,13 @@ class Session extends process.EventEmitter
         'Authorization': @auth
         'Accept': 'application/json'
 
-    request options, (error, res, body) =>
-      if error
-        @emit 'error', 'Couldn\'t connect to Flowdock'
-        return
+    request options, (err, res, body) =>
+      if err
+        error = 'Couldn\'t connect to Flowdock'
       else if res.statusCode >= 300
-        @emit 'error', res.statusCode
-        return
-      callback(body, res) if callback?
+        error = 'Received status ' + res.statusCode
+      @emit 'error', error if error?
+      callback(error, body, res) if callback?
 
   # Send a chat message to Flowdock
   message: (flowId, message, tags, callback) ->


### PR DESCRIPTION
Turns callbacks to more idiomatic node.

Fixes #11.
