### PR TITLE
General http methods for api interactions

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -99,11 +99,24 @@ session.privateMessage(12345, 'Hi, this is a secret message!');
 ```
 The first argument is the recipient's ID.
 
-### Invite user to Flow
+#### Invite user to Flow
 ```javascript
-session.invite('6f67fd0b-b764-4661-9e53-c38293d1e997', 'organizationId', 'email@example.com', 'Please join to our flow!');
+// Note that flow and organization ids must be the "parameterized_name" from api response.
+session.invite('my-flow', 'example-organization', 'email@example.com', 'Please join to our flow!');
 ```
 The first argument is flow id, second is organization id, third is email where the invitation is sent and fourth is message that is sent with invitation.
+
+#### Edit a message
+```javascript
+session.editMessage(
+  'my-flow',
+  'example-organization',
+  {content: 'new content'},
+  function (err, message, response) {
+    /* do something */
+  }
+)
+```
 
 #### Fetch and stream all the flows your user has an access
 
@@ -128,6 +141,28 @@ session.flows(function(err, flows) {
 });
 ```
 The full message format specification for different message types is in [Flowdock API Message documentation](https://www.flowdock.com/api/messages).
+
+## API usage
+
+The Session object can be used as an api wrapper and it has basic http request functions (get, post, put, delete). All accept same parameters: `path`, `data` and `callback`. For example fetching a single flow by id:
+
+```javascript
+session.get(
+  '/flows/find',
+  {id: '6f67fd0b-b764-4661-9e53-c38293d1e997'},
+  function (err, flow, response) {
+    /* do something */
+  }
+);
+```
+
+Or delete a message:
+
+```javascript
+path = flow.url + "/messages/" + message.id;
+session.delete(path, function (err) {
+  /* do something */
+});
 
 ## Development
 

--- a/test/flowdock.test.coffee
+++ b/test/flowdock.test.coffee
@@ -10,20 +10,52 @@ describe 'Flowdock', ->
     process.env.FLOWDOCK_STREAM_URL = "http://localhost:#{mockdock.port}"
     process.env.FLOWDOCK_API_URL = "http://localhost:#{mockdock.port}"
     session = new flowdock.Session('test', 'password')
+    session.on 'error', -> #noop
 
   afterEach ->
     mockdock.removeAllListeners()
 
   describe 'stream', ->
-    it 'can handle array parameter', ->
+    it 'can handle array parameter', (done) ->
+      mockdock.on 'request', (req, res) ->
+        assert.equal req.url, '/?filter=example%3Amain%2Cexample%3Atest'
+        res.setHeader('Content-Type', 'application/json')
+        res.end('{}')
       stream = session.stream ['example:main', 'example:test']
+      stream.on 'connected', ->
+        stream.removeAllListeners()
+        done()
       assert.deepEqual stream.flows, ['example:main', 'example:test']
 
-    it 'can handle single flow', ->
+    it 'can handle single flow', (done) ->
+      mockdock.on 'request', (req, res) ->
+        assert.equal req.url, '/?filter=example%3Amain'
+        res.setHeader('Content-Type', 'application/json')
+        res.end('{}')
       stream = session.stream 'example:main'
+      stream.on 'connected', ->
+        stream.removeAllListeners()
+        done()
       assert.deepEqual stream.flows, ['example:main']
 
   describe 'invitations', ->
-    it 'can send an invitation', ->
-      session.invite 'org1', 'flow1', 'test@localhost', 'test message', (result) ->
-        result.state.should.equal 'pending'
+    it 'can send an invitation', (done) ->
+      mockdock.on 'request', (req, res) ->
+        assert.equal req.url, '/flows/org1/flow1/invitations'
+        res.setHeader('Content-Type', 'application/json')
+        res.end('{}')
+      session.invite 'flow1', 'org1', 'test@localhost', 'test message', (err, data, result) ->
+        assert.equal err, null
+        done()
+
+  describe '_request', ->
+    it 'makes a sensible request', (done) ->
+      mockdock.on 'request', (req, res) ->
+        assert.equal req.url, '/flows/find?id=acdcabbacd1234567890'
+        res.setHeader('Content-Type', 'application/json')
+        res.end('{"flow":"foo"}')
+      session._request 'get', '/flows/find', {id: 'acdcabbacd1234567890'}, (err, data, res) ->
+        assert.equal err, null
+        assert.deepEqual data, {flow: "foo"}
+        done()
+


### PR DESCRIPTION
Added post/get/delete/put api wrapper methods to `Session` and refactor existing functionality to use them.

Fixes #14 by adding an `editMessage` method.
