### PR TITLE
Allow URL to be (optionally) passed to Session()

### DIFF
--- a/src/flowdock.coffee
+++ b/src/flowdock.coffee
@@ -10,12 +10,9 @@ extend = (objects...) ->
       result[key] = value
   result
 
-baseURL = ->
-  url.parse(process.env.FLOWDOCK_API_URL || 'https://api.flowdock.com')
-
 class Session extends process.EventEmitter
 
-  constructor: (@email, @password) ->
+  constructor: (@email, @password, @url = process.env.FLOWDOCK_API_URL || 'https://api.flowdock.com') ->
     @auth = 'Basic ' + new Buffer(@email + ':' + @password).toString('base64')
 
   flows: (callback) ->
@@ -104,7 +101,7 @@ class Session extends process.EventEmitter
     @_request('delete', path, {}, cb)
 
   _request: (method, path, data, cb) ->
-    uri = baseURL()
+    uri = @baseURL()
     uri.pathname = path
     if method.toLowerCase() == 'get'
       qs = data
@@ -129,5 +126,8 @@ class Session extends process.EventEmitter
         cb?(error)
       else
         cb?(null, body, res)
+
+  baseURL: () ->
+    url.parse(@url)
 
 exports.Session = Session

--- a/test/flowdock.test.coffee
+++ b/test/flowdock.test.coffee
@@ -59,3 +59,18 @@ describe 'Flowdock', ->
         assert.deepEqual data, {flow: "foo"}
         done()
 
+  describe 'Session', ->
+    it 'should optionally take a URL', (done) ->
+      alt_mockdock = Mockdock.start()
+      alt_session = new flowdock.Session('test', 'password', "http://localhost:#{alt_mockdock.port}")
+      
+      alt_mockdock.on 'request', (req, res) ->
+        assert.equal req.url, '/flows/find?id=acdcabbacd1234567890'
+        res.setHeader('Content-Type', 'application/json')
+        res.end('{"flow":"foo"}')
+      alt_session._request 'get', '/flows/find', {id: 'acdcabbacd1234567890'}, (err, data, res) ->
+        assert.equal err, null
+        assert.deepEqual data, {flow: "foo"}
+        alt_mockdock.removeAllListeners()
+        done()
+      


### PR DESCRIPTION
@lautis: Thanks for an excellent library, it has made our Flowdock integration much easier.

In writing an end-to-end regression test for our flowdock integration, we wanted to mock the flowdock API server (like the flowdock tests do), so we discovered and used the `FLOWDOCK_API_URL` environment variable to point flowdock at our mock API server.

But I didn't feel comfortable relying on an undocumented environment variable and thought it might be clearer to allow the API URL as an optional argument in the Session constructor (in addition to respecting the environment variable), hence this pull request.

I included a test; if you're interested I can include a README update as well.