### PR TITLE
Remove binary dependency and update Node

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "lib": "./lib"
   },
   "dependencies": {
-    "buffertools": "~2.1.3",
+    "buffer-indexof": "^1.0.0",
     "request": "~2.58.0"
   },
   "devDependencies": {

--- a/src/flowdock.coffee
+++ b/src/flowdock.coffee
@@ -10,7 +10,7 @@ extend = (objects...) ->
       result[key] = value
   result
 
-class Session extends process.EventEmitter
+class Session extends events.EventEmitter
 
   constructor: (@email, @password, @url = process.env.FLOWDOCK_API_URL || 'https://api.flowdock.com') ->
     @auth = 'Basic ' + new Buffer(@email + ':' + @password).toString('base64')

--- a/src/json_stream.coffee
+++ b/src/json_stream.coffee
@@ -1,9 +1,10 @@
-buffertools = require 'buffertools'
+bufIndexOf = require 'buffer-indexof'
 stream = require 'stream'
 
 # Carriage-return delimited stream of JSON objects
 class JSONStream extends stream.Stream
   LF = "\r\n"
+  LFB = new Buffer(LF)
   constructor: ->
     @buffer = new Buffer 0
     @writable = true
@@ -16,10 +17,10 @@ class JSONStream extends stream.Stream
     input = Buffer.isBuffer(chunk) && chunk || new Buffer(chunk, encoding)
 
     # concatenate input to @buffer
-    @buffer = buffertools.concat @buffer, input
+    @buffer = Buffer.concat [@buffer, input]
 
     # split the buffer from the first \r\n and leave the rest into @buffer as a new Buffer
-    while ((index = buffertools.indexOf(@buffer, LF)) > -1)
+    while ((index = bufIndexOf(@buffer, LFB)) > -1)
       ret = @buffer.slice(0, index)
       @buffer = new Buffer @buffer.slice(index + LF.length)
       @emit 'data', JSON.parse(ret.toString('utf8')) # TODO: 4-byte UTF-8 character handling

--- a/src/stream.coffee
+++ b/src/stream.coffee
@@ -1,4 +1,5 @@
 url = require 'url'
+events = require 'events'
 request = require 'request'
 JSONStream = require './json_stream'
 
@@ -14,7 +15,7 @@ backoff = (backoff, errors, operator = '*') ->
       Math.pow 2, errors - 1) * backoff.delay
   )
 
-class Stream extends process.EventEmitter
+class Stream extends events.EventEmitter
   constructor: (@auth, @flows, @params = {}) ->
     @networkErrors = 0
     @responseErrors = 0

--- a/test/helper.coffee
+++ b/test/helper.coffee
@@ -1,7 +1,8 @@
+events = require 'events'
 http = require 'http'
 
 # Fake Flowdock Streaming API, do whatever you want
-class Mockdock extends process.EventEmitter
+class Mockdock extends events.EventEmitter
   request: (req, res) =>
     @emit 'request', req, res
   constructor: (@port) ->


### PR DESCRIPTION
- Remove binary `buffertools` dependency (more portable, can run on Node nightly builds)
- Use `Buffer.concat` instead of `buffertools.concat`
- Use `buffer-indexof` module instead of `buffertools.indexOf` (`Buffer.prototype.indexOf` is present since Node 4 but this module is still needed for legacy support)
- Use `events.EventEmitter` instead of `process.EventEmitter` (the latter shows a deprecation message in Node 6)

I could get the tests to pass on Node 0.8.0 to 6.0.0.
