### PR TITLE
fix deprecated process.EventEmitter

### DIFF
--- a/src/flowdock.coffee
+++ b/src/flowdock.coffee
@@ -2,6 +2,7 @@ url = require 'url'
 events = require 'events'
 request = require 'request'
 Stream = require './stream'
+EventEmitter = require 'events'
 
 extend = (objects...) ->
   result = {}
@@ -10,7 +11,7 @@ extend = (objects...) ->
       result[key] = value
   result
 
-class Session extends process.EventEmitter
+class Session extends EventEmitter
 
   constructor: (@email, @password, @url = process.env.FLOWDOCK_API_URL || 'https://api.flowdock.com') ->
     @auth = 'Basic ' + new Buffer(@email + ':' + @password).toString('base64')

--- a/src/flowdock.coffee
+++ b/src/flowdock.coffee
@@ -2,7 +2,7 @@ url = require 'url'
 events = require 'events'
 request = require 'request'
 Stream = require './stream'
-EventEmitter = require 'events'
+EventEmitter = process.EventEmitter || require 'events'
 
 extend = (objects...) ->
   result = {}

--- a/src/stream.coffee
+++ b/src/stream.coffee
@@ -1,6 +1,7 @@
 url = require 'url'
 request = require 'request'
 JSONStream = require './json_stream'
+EventEmitter = require 'events'
 
 baseURL = ->
   url.parse(process.env.FLOWDOCK_STREAM_URL || 'https://stream.flowdock.com/flows')
@@ -14,8 +15,9 @@ backoff = (backoff, errors, operator = '*') ->
       Math.pow 2, errors - 1) * backoff.delay
   )
 
-class Stream extends process.EventEmitter
+class Stream extends EventEmitter
   constructor: (@auth, @flows, @params = {}) ->
+    console.log(typeof __super__)
     @networkErrors = 0
     @responseErrors = 0
     @on 'reconnecting', (timeout) =>

--- a/src/stream.coffee
+++ b/src/stream.coffee
@@ -1,7 +1,7 @@
 url = require 'url'
 request = require 'request'
 JSONStream = require './json_stream'
-EventEmitter = require 'events'
+EventEmitter = process.EventEmitter || require 'events'
 
 baseURL = ->
   url.parse(process.env.FLOWDOCK_STREAM_URL || 'https://stream.flowdock.com/flows')

--- a/test/helper.coffee
+++ b/test/helper.coffee
@@ -1,7 +1,8 @@
 http = require 'http'
+EventEmitter = process.EventEmitter || require 'events'
 
 # Fake Flowdock Streaming API, do whatever you want
-class Mockdock extends process.EventEmitter
+class Mockdock extends EventEmitter
   request: (req, res) =>
     @emit 'request', req, res
   constructor: (@port) ->


### PR DESCRIPTION
process.EventEmitter has been removed in node 7 and replaced by the events module.

This PR applies this change. 

This seems to fix it for me.